### PR TITLE
Delete ABControls copy-Info.plist File

### DIFF
--- a/ABControls.xcodeproj/project.pbxproj
+++ b/ABControls.xcodeproj/project.pbxproj
@@ -89,7 +89,6 @@
 		B4FEDD022116419200223E77 /* ABControls.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ABControls.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4FEDD052116419200223E77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EF73BD29212324EF001BEBE1 /* ABControls.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ABControls.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EF73BD2A212324EF001BEBE1 /* ABControls copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "ABControls copy-Info.plist"; path = "/Users/michaelcollins/Projects/mfcollins3/ABControls/ABControls copy-Info.plist"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,7 +117,6 @@
 				B46D4E252114C05F00A58C71 /* ABControls */,
 				B46D4E242114C05F00A58C71 /* Products */,
 				B4FEDCFB2116411700223E77 /* Frameworks */,
-				EF73BD2A212324EF001BEBE1 /* ABControls copy-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};

--- a/ABControls.xcodeproj/xcshareddata/xcschemes/ABControls-Static.xcscheme
+++ b/ABControls.xcodeproj/xcshareddata/xcschemes/ABControls-Static.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "EF73BD04212324EF001BEBE1"
-               BuildableName = "ABControls-Static.framework"
+               BuildableName = "ABControls.framework"
                BlueprintName = "ABControls-Static"
                ReferencedContainer = "container:ABControls.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EF73BD04212324EF001BEBE1"
-            BuildableName = "ABControls-Static.framework"
+            BuildableName = "ABControls.framework"
             BlueprintName = "ABControls-Static"
             ReferencedContainer = "container:ABControls.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EF73BD04212324EF001BEBE1"
-            BuildableName = "ABControls-Static.framework"
+            BuildableName = "ABControls.framework"
             BlueprintName = "ABControls-Static"
             ReferencedContainer = "container:ABControls.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
I deleted the reference to `ABControls copy-Info.plist`. This file was
not necessary and I deleted it from the repo, but I did not remove the
reference from the Xcode project. I removed the reference.